### PR TITLE
Also Use <td> For Head Column Definitions

### DIFF
--- a/css/footable-0.1.css
+++ b/css/footable-0.1.css
@@ -1,4 +1,4 @@
-﻿.footable > thead > tr > th {
+﻿.footable > thead > tr > th,.footable > thead > tr > td {
   position: relative;
 }
 
@@ -42,7 +42,7 @@
   text-align: left;
 }
 
-.footable > thead > tr > th {
+.footable > thead > tr > th, .footable > thead > tr > td {
   background-color: #dce9f9;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#ebf3fc), to(#dce9f9));
   background-image: -webkit-linear-gradient(top, #ebf3fc, #dce9f9);
@@ -57,19 +57,19 @@
   text-shadow: 0 1px 0 rgba(255,255,255,.5);
 }
 
-.footable > thead > tr > th:first-child {
+.footable > thead > tr > th:first-child, .footable > thead > tr > td:first-child {
   -moz-border-radius: 6px 0 0 0;
   -webkit-border-radius: 6px 0 0 0;
   border-radius: 6px 0 0 0;
 }
 
-.footable > thead > tr > th:last-child {
+.footable > thead > tr > th:last-child, .footable > thead > tr > td:last-child {
   -moz-border-radius: 0 6px 0 0;
   -webkit-border-radius: 0 6px 0 0;
   border-radius: 0 6px 0 0;
 }
 
-.footable > thead > tr > th:only-child {
+.footable > thead > tr > th:only-child, .footable > thead > tr > td:only-child {
   -moz-border-radius: 6px 6px 0 0;
   -webkit-border-radius: 6px 6px 0 0;
   border-radius: 6px 6px 0 0;

--- a/js/footable-0.1.js
+++ b/js/footable-0.1.js
@@ -185,7 +185,7 @@
       $table.addClass(cls.loading);
 
       // Get the column data once for the life time of the plugin
-      $table.find('> thead > tr > th').each(function() {
+      $table.find('> thead > tr > th, > thead > tr > td').each(function() {
         var data = ft.getColumnData(this);
         ft.columns[data.index] = data;
 


### PR DESCRIPTION
Modified selector and styles to use '> thead > tr > td' in addition to the default '> thead > tr > th'. This allows FooTable to work with legacy tables, as well as tables created with certain versions of TinyMCE. 
