### PR TITLE
adding .last to the last th and td

### DIFF
--- a/css/footable-0.1.css
+++ b/css/footable-0.1.css
@@ -63,7 +63,7 @@
   border-radius: 6px 0 0 0;
 }
 
-.footable > thead > tr > th:last-child, .footable > thead > tr > td:last-child {
+.footable > thead > tr > th.last, .footable > thead > tr > td.last {
   -moz-border-radius: 0 6px 0 0;
   -webkit-border-radius: 0 6px 0 0;
   border-radius: 0 6px 0 0;
@@ -81,7 +81,7 @@
   border-radius: 0 0 0 6px;
 }
 
-.footable > tbody > tr:last-child > td:last-child {
+.footable > tbody > tr:last-child > td.last {
   -moz-border-radius: 0 0 6px 0;
   -webkit-border-radius: 0 0 6px 0;
   border-radius: 0 0 6px 0;

--- a/css/footable-0.1.css
+++ b/css/footable-0.1.css
@@ -63,7 +63,7 @@
   border-radius: 6px 0 0 0;
 }
 
-.footable > thead > tr > th.last, .footable > thead > tr > td.last {
+.footable > thead > tr > th.footable-last-column, .footable > thead > tr > td.footable-last-column {
   -moz-border-radius: 0 6px 0 0;
   -webkit-border-radius: 0 6px 0 0;
   border-radius: 0 6px 0 0;
@@ -81,7 +81,7 @@
   border-radius: 0 0 0 6px;
 }
 
-.footable > tbody > tr:last-child > td.last {
+.footable > tbody > tr:last-child > td.footable-last-column {
   -moz-border-radius: 0 0 6px 0;
   -webkit-border-radius: 0 0 6px 0;
   border-radius: 0 0 6px 0;

--- a/js/footable-0.1.js
+++ b/js/footable-0.1.js
@@ -348,6 +348,12 @@
             else $next.show();
           }
         });
+        
+        // adding .last to the last th and td in order to allow for styling if the last column is hidden (which won't work using :last-child)
+        $table.find('> thead > tr > th.last').removeClass('last');
+        $table.find('> thead > tr > th:visible').last().addClass('last')
+        $table.find('> tbody > tr > td.last').removeClass('last');
+        $table.find('> tbody > tr > td:visible').last().addClass('last')          
 
         ft.raise('footable_breakpoint_' + breakpointName, { 'info': info });
       }

--- a/js/footable-0.1.js
+++ b/js/footable-0.1.js
@@ -351,9 +351,9 @@
         
         // adding .last to the last th and td in order to allow for styling if the last column is hidden (which won't work using :last-child)
         $table.find('> thead > tr > th.last').removeClass('last');
-        $table.find('> thead > tr > th:visible').last().addClass('last')
+        $table.find('> thead > tr > th:visible').last().addClass('last');
         $table.find('> tbody > tr > td.last').removeClass('last');
-        $table.find('> tbody > tr > td:visible').last().addClass('last')          
+        $table.find('> tbody > tr > td:visible').last().addClass('last');
 
         ft.raise('footable_breakpoint_' + breakpointName, { 'info': info });
       }

--- a/js/footable-0.1.js
+++ b/js/footable-0.1.js
@@ -245,11 +245,6 @@
         if ($table.is('.breakpoint')) {
           var $row = $(this).is('tr') ? $(this) : $(this).parents('tr:first');
           ft.toggleDetail($row.get(0));
-          
-           if (typeof opt.onExpand == 'function') { // make sure the callback is a function
-             opt.onExpand.call(this); // brings the scope to the callback
-           }          
-          
         }
       });      
     };

--- a/js/footable-0.1.js
+++ b/js/footable-0.1.js
@@ -245,6 +245,11 @@
         if ($table.is('.breakpoint')) {
           var $row = $(this).is('tr') ? $(this) : $(this).parents('tr:first');
           ft.toggleDetail($row.get(0));
+          
+           if (typeof opt.onExpand == 'function') { // make sure the callback is a function
+             opt.onExpand.call(this); // brings the scope to the callback
+           }          
+          
         }
       });      
     };
@@ -349,11 +354,9 @@
           }
         });
         
-        // adding .last to the last th and td in order to allow for styling if the last column is hidden (which won't work using :last-child)
-        $table.find('> thead > tr > th.last').removeClass('last');
-        $table.find('> thead > tr > th:visible').last().addClass('last');
-        $table.find('> tbody > tr > td.last').removeClass('last');
-        $table.find('> tbody > tr > td:visible').last().addClass('last');
+        // adding .footable-last-column to the last th and td in order to allow for styling if the last column is hidden (which won't work using :last-child)
+       $table.find('> thead > tr > th.footable-last-column,> tbody > tr > td.footable-last-column').removeClass('footable-last-column');
+       $table.find('> thead > tr > th:visible:last,> tbody > tr > td:visible:last').addClass('footable-last-column');
 
         ft.raise('footable_breakpoint_' + breakpointName, { 'info': info });
       }


### PR DESCRIPTION
This is needed in order to allow styling if the last column is hidden
(which won't work using :last-child).

You can see this problem when scaling the demo.htm down to the phone
breakpoint. The top-right and lower-right corners will not have the
correct border-radius applied.

Not sure if the JS-part is the most effective performance-wise … but it
works fine for me.
