### PR TITLE
Reset .jshintrc file to pass jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,15 +1,89 @@
 {
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
-  "undef": true,
-  "unused": true,
-  "boss": true,
-  "eqnull": true,
-  "node": true,
-  "es5": true
+    // Unknown option names (and their error messages)
+    "-W030": false, // Expected an assignment or function call and instead saw an expression.
+    "-W032": false, // Unnecessary semicolon.
+    "-W035": false, // Empty block.
+    "-W041": false, // Use '!==' to compare with 'true'. // Use '===' to compare with 'true'. // Use '===' to compare with 'false'. // Use '===' to compare with 'undefined'. // Use '===' to compare with '0'.
+    "-W065": false, // Missing radix parameter.
+    "-W069": false, // ['name'] is better written in dot notation.
+    "-W071": false, // This function has too many statements.
+    "-W072": false, // This function has too many parameters.
+    "-W073": false, // Blocks are nested too deeply.
+    "-W074": false, // This function's cyclomatic complexity is too high.
+    "-W083": false, // Don't make functions within a loop.
+    "-W089": false, // The body of a for in should be wrapped in an if statement to filter unwanted properties from the prototype.
+    "-W101": false, // Line is too long.
+    "-W117": false, // 'variablename' is not defined.
+
+    // Enforcing options
+    "bitwise": true,
+    "camelcase": true,
+    "curly": false, // partial W116
+    "eqeqeq": false, // partial W116
+    "es3": true,
+    "forin": true,
+    "immed": true,
+    "indent": false, // W015
+    "latedef": true,
+    "newcap": false, // W055
+    "noarg": true,
+    "noempty": true,
+    "nonew": true,
+    "plusplus": false, // W016
+    "quotmark": false, // W110
+    "undef": true,
+    "unused": false, // W098
+    "strict": false, // E007
+    "trailing": false, // W102
+    "maxparams": true,
+    "maxdepth": true,
+    "maxstatements": true,
+    "maxcomplexity": true,
+    "maxlen": true,
+
+    // Relaxing options
+    "asi": false,
+    "boss": false,
+    "debug": false,
+    "eqnull": true, // partial W041
+    "esnext": false,
+    "evil": false,
+    "expr": false,
+    "funcscope": false,
+    "globalstrict": false,
+    "iterator": false,
+    "lastsemic": false,
+    "laxbreak": false,
+    "laxcomma": false,
+    "loopfunc": false,
+    "moz": false,
+    "multistr": false,
+    "proto": false,
+    "scripturl": false,
+    "smarttabs": true, // W099
+    "shadow": false,
+    "sub": false,
+    "supernew": false,
+    "validthis": false,
+
+    // Environments
+    "browser": true, // partial W117
+    "couch": false,
+    "devel": false,
+    "dojo": false,
+    "jquery": true, // partial W117
+    "mootools": false,
+    "node": false,
+    "nonstandard": false,
+    "prototypejs": false,
+    "rhino": false,
+    "worker": false,
+    "wsh": false,
+    "yui": false,
+
+    // Legacy
+    "nomen": false,
+    "onevar": false,
+    "passfail": false,
+    "white": false
 }


### PR DESCRIPTION
Currently FooTable was failing it's JSHint settings. A good way to get compliant is starting with a config that allows the current code to pass as-is. Then you start flipping the settings one by one and changing the code to be compliant. It's like paying off your credit-cards, you start with the worst one and take one at a time. :)

This PR configures JSHint to pass the code as-is. You should start by flipping the first flags, that start with `-W`, as they're so agreed upon within the JS community that they don't have regular named option flags.
