### PR TITLE
Fix Travis-CI and JSHint with GruntJS

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,36 +1,17 @@
 {
-    // Unknown option names (and their error messages)
-    "-W030": false, // Expected an assignment or function call and instead saw an expression.
-    "-W032": false, // Unnecessary semicolon.
-    "-W035": false, // Empty block.
-    "-W041": false, // Use '!==' to compare with 'true'. // Use '===' to compare with 'true'. // Use '===' to compare with 'false'. // Use '===' to compare with 'undefined'. // Use '===' to compare with '0'.
-    "-W065": false, // Missing radix parameter.
-    "-W069": false, // ['name'] is better written in dot notation.
-    "-W071": false, // This function has too many statements.
-    "-W072": false, // This function has too many parameters.
-    "-W073": false, // Blocks are nested too deeply.
-    "-W074": false, // This function's cyclomatic complexity is too high.
-    "-W083": false, // Don't make functions within a loop.
-    "-W089": false, // The body of a for in should be wrapped in an if statement to filter unwanted properties from the prototype.
-    "-W101": false, // Line is too long.
-    "-W117": false, // 'variablename' is not defined.
+    "curly":    false,
+    "eqeqeq":   false,
+    "indent":   false,
+    "newcap":   false,
+    "plusplus": false,
+    "quotmark": false,
+    "unused":   false,
+    "strict":   false,
+    "trailing": false,
 
-    // Enforcing options
-    "curly":    false, // partial W116
-    "eqeqeq":   false, // partial W116
-    "indent":   false, // W015
-    "newcap":   false, // W055
-    "plusplus": false, // W016
-    "quotmark": false, // W110
-    "unused":   false, // W098
-    "strict":   false, // E007
-    "trailing": false, // W102
+    "eqnull":    true,
+    "smarttabs": true,
 
-    // Relaxing options
-    "eqnull":    true, // partial W041
-    "smarttabs": true, // W099
-
-    // Environments
-    "browser":   true, // partial W117
-    "jquery":    true  // partial W117
+    "browser":   true,
+    "jquery":    true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,17 +1,20 @@
 {
-    "curly":    false,
-    "eqeqeq":   false,
-    "indent":   false,
-    "newcap":   false,
+    "curly": false,
+    "eqeqeq": false,
+    "indent": false,
+    "newcap": false,
     "plusplus": false,
     "quotmark": false,
-    "unused":   false,
-    "strict":   false,
+    "unused": false,
+    "strict": false,
     "trailing": false,
+    "maxstatements": false,
+    "maxlen": false,
 
-    "eqnull":    true,
+    "eqnull": true,
     "smarttabs": true,
 
-    "browser":   true,
-    "jquery":    true
+    "browser": true,
+    "jquery": true,
+    "node": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
     grunt.initConfig({
         pkg: grunt.file.readJSON('footable.jquery.json'),
@@ -45,8 +45,8 @@ module.exports = function(grunt) {
             src: {
                 files: '<%= jshint.src.src %>',
                 tasks: ['jshint:src']
-            },
-        },
+            }
+        }
     });
 
     // Load grunt tasks

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -1,15 +1,29 @@
 {
-  "curly": true,
-  "eqeqeq": true,
-  "immed": true,
-  "latedef": true,
-  "newcap": true,
-  "noarg": true,
-  "sub": true,
-  "undef": true,
-  "unused": true,
-  "boss": true,
-  "eqnull": true,
-  "browser": true,
-  "predef": ["jQuery"]
+    "curly": false,
+    "eqeqeq": false,
+    "forin": false,
+    "indent": false,
+    "newcap": false,
+    "plusplus": false,
+    "quotmark": false,
+    "undef": false,
+    "unused": false,
+    "strict": false,
+    "trailing": false,
+    "maxparams": false,
+    "maxdepth": false,
+    "maxstatements": false,
+    "maxcomplexity": false,
+    "maxlen": false,
+
+    "eqnull": true,
+    "loopfunc": true,
+    "smarttabs": true,
+    "sub": true,
+
+    "browser": true,
+    "jquery": true,
+    "node": true,
+
+    "white": false
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.9" // Needed for Travis-CI. Not recommended otherwise, it should be installed globally.
+    "grunt-cli": "~0.1.9"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Travis-CI is now running properly and failing the build because JSHint isn't passing. I had used `jshint` from `npm` to create that previous jshint config file and it allowed suppressing specific warnings, but `jshint` from `grunt` behaves differently so `grunt test` isn't passing atm.

I will do a separate PR to deal with the JSHint errors, but you might want to take a look at them first because some's about usage of `===` and `==` which you seem to be doing incorrectly.
