### PR TITLE
Gitignore update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,22 +1,2 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-
-# Custom for Visual Studio
-*.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union
-
-# Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ pip-log.txt
 
 # WebStorm IDE
 /.idea
+
+# npm
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -44,57 +44,14 @@ local.properties
 # Build results
 [Dd]ebug/
 [Rr]elease/
-*_i.c
-*_p.c
-*.ilk
-*.meta
-*.obj
-*.pch
-*.pdb
-*.pgc
-*.pgd
-*.rsp
-*.sbr
-*.tlb
-*.tli
-*.tlh
-*.tmp
-*.vspscc
-.builds
-*.dotCover
-
-## TODO: If you have NuGet Package Restore enabled, uncomment this
-#packages/
-
-# Visual C++ cache files
-ipch/
-*.aps
-*.ncb
-*.opensdf
-*.sdf
 
 # Visual Studio profiler
 *.psess
 *.vsp
 
-# ReSharper is a .NET coding add-in
+# ReSharper and DotCover are .NET coding add-in
 _ReSharper*
-
-# Installshield output folder
-[Ee]xpress
-
-# DocProject is a documentation generator add-in
-DocProject/buildhelp/
-DocProject/Help/*.HxT
-DocProject/Help/*.HxC
-DocProject/Help/*.hhc
-DocProject/Help/*.hhk
-DocProject/Help/*.hhp
-DocProject/Help/Html2
-DocProject/Help/html
-
-# Click-Once directory
-publish
+*.dotCover
 
 # Others
 [Bb]in
@@ -116,35 +73,11 @@ UpgradeLog*.XML
 
 
 
-############
-## Windows
-############
-
 # Windows image file caches
 Thumbs.db
 
-# Folder config file
+# Windows folder config file
 Desktop.ini
-
-
-#############
-## Python
-#############
-
-*.py[co]
-
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
-.installed.cfg
 
 # Installer logs
 pip-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ pip-log.txt
 # Grunt related
 /node_modules/
 /dist/
+
+# WebStorm IDE
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,6 @@ pip-log.txt
 
 # Grunt related
 /node_modules/
-/dist/
 
 # WebStorm IDE
 /.idea


### PR DESCRIPTION
1) WebStorm IDE (which I use) creates an /.idea folder that I'd like to have ignored.
2) The /dist folder was already ignored but it shouldn't, you should use that folder for distribution version of FooTable
## Question

@bradvin
The .gitignore and .gitattributes are a bit zealus. They define how to handle Visual Studio files and ignores Python, which doesn't make sense in this project since those aren't in the repository? Can I clean up a bit? Then let me know and wait with merging this.
