### PR TITLE
Adding 'forceResize' parameter to 'ft.resize()' method - defaults to: false

### DIFF
--- a/js/footable.js
+++ b/js/footable.js
@@ -472,7 +472,10 @@
             return false;
         };
 
-        ft.resize = function () {
+        ft.resize = function (forceResize) {
+            if(typeof forceResize == "undefined") { 
+                forceResize = false; 
+            }
             var $table = $(ft.table);
 
             if (!$table.is(':visible')) { return; } //we only care about FooTables that are visible
@@ -494,7 +497,7 @@
             ft.raise(evt.resizing, { 'old': pinfo, 'info': info });
 
             // This (if) statement is here purely to make sure events aren't raised twice as mobile safari seems to do
-            if (!pinfo || ((pinfo && pinfo.width && pinfo.width !== info.width) || (pinfo && pinfo.height && pinfo.height !== info.height))) {
+            if ((!pinfo || ((pinfo && pinfo.width && pinfo.width !== info.width) || (pinfo && pinfo.height && pinfo.height !== info.height))) || forceResize == true) {
                 var current = null, breakpoint;
                 for (var i = 0; i < ft.breakpoints.length; i++) {
                     breakpoint = ft.breakpoints[i];

--- a/js/footable.js
+++ b/js/footable.js
@@ -497,7 +497,7 @@
             ft.raise(evt.resizing, { 'old': pinfo, 'info': info });
 
             // This (if) statement is here purely to make sure events aren't raised twice as mobile safari seems to do
-            if ((!pinfo || ((pinfo && pinfo.width && pinfo.width !== info.width) || (pinfo && pinfo.height && pinfo.height !== info.height))) || forceResize == true) {
+            if ((!pinfo || ((pinfo && pinfo.width && pinfo.width !== info.width) || (pinfo && pinfo.height && pinfo.height !== info.height))) || forceResize === true) {
                 var current = null, breakpoint;
                 for (var i = 0; i < ft.breakpoints.length; i++) {
                     breakpoint = ft.breakpoints[i];
@@ -514,7 +514,7 @@
                 $table.data('breakpoint', breakpointName);
 
                 //only do something if the breakpoint has changed
-                if ( breakpointName !== previousBreakpoint || forceResize == true) {
+                if ( breakpointName !== previousBreakpoint || forceResize === true) {
                     $table
                         .find('> tbody > tr:not(.' + cls.detail + ')').data('detail_created', false).end()
                         .removeClass('default breakpoint').removeClass(ft.breakpointNames)

--- a/js/footable.js
+++ b/js/footable.js
@@ -514,7 +514,7 @@
                 $table.data('breakpoint', breakpointName);
 
                 //only do something if the breakpoint has changed
-                if ( breakpointName !== previousBreakpoint ) {
+                if ( breakpointName !== previousBreakpoint || forceResize == true) {
                     $table
                         .find('> tbody > tr:not(.' + cls.detail + ')').data('detail_created', false).end()
                         .removeClass('default breakpoint').removeClass(ft.breakpointNames)


### PR DESCRIPTION
@Bravdin, 

I thought of a less intrusive way to force the ft.resize() method (AKA redraw) that we were talking about this week.  It works with the column picker plugin.  If this works for you, go ahead and merge it in.  Did you want me to submit a pull request for the column picker or would that be better hosted in its own repository?  I figured, either way, I'd wait until we have the force redraw issue figured out. 
