### PR TITLE
Fix ReferenceError: $table is not defined

### DIFF
--- a/js/footable.striping.js
+++ b/js/footable.striping.js
@@ -24,7 +24,7 @@
         .bind({
           'footable_initialized.striping footable_row_removed.striping footable_redrawn.striping footable_sorted.striping footable_filtered.striping': function () {
             
-            if ($table.data('striping') === false) return;
+            if ($(this).data('striping') === false) return;
 
             p.setupStriping(ft);
           }


### PR DESCRIPTION
$table is not defined. $(this) references the same element as $(ft.table) which, in other plugins, is analogous to $table.
