### PR TITLE
FIX striping for pagination

### DIFF
--- a/js/footable.striping.js
+++ b/js/footable.striping.js
@@ -34,7 +34,7 @@
     p.setupStriping = function (ft) {
 
       var rowIndex = 0;
-      $(ft.table).find('> tbody > tr:visible:not(.footable-row-detail)').each(function () {
+      $(ft.table).find('> tbody > tr:not(.footable-row-detail)').each(function () {
 
         var $row = $(this);
 


### PR DESCRIPTION
Hi,

I'm not sure why the footable-odd and footable-even classes are set only on visible tr but when pagination is on, the striping works only on the first page.
If I remove :visible, it works for me.

Regards,
Emmanuel
