### PR TITLE
Ability to pass textExtractor as an option to footable

### DIFF
--- a/js/footable.js
+++ b/js/footable.js
@@ -434,8 +434,12 @@
         };
 
         ft.parse = function (cell, column) {
-            var parser = opt.parsers[column.type] || opt.parsers.alpha;
-            return parser(cell);
+            if(ft.options.textExtractor) {
+                return ft.options.textExtractor(cell);
+            } else {
+                var parser = opt.parsers[column.type] || opt.parsers.alpha;
+                return parser(cell);
+            }
         };
 
         ft.getColumnData = function (th) {

--- a/js/footable.sort.js
+++ b/js/footable.sort.js
@@ -169,6 +169,9 @@
         p.sort = function (ft, tbody, column, ascending) {
             var rows = p.rows(ft, tbody, column);
             var sorter = ft.options.sorters[column.type] || ft.options.sorters.alpha;
+            if(ft.options.textExtractor) {
+                sorter = ft.options.sorters.alpha;
+            }
             rows.sort(function (a, b) {
                 if (ascending) {
                     return sorter(a.value, b.value);


### PR DESCRIPTION
This enables the programmer to override the normal text parsing behavior in footable, and instead provide a function that, given a cell within the table, returns the 'sort value'.

In my current implementation, when this feature is used, the parser is forced to aplha. This may not be the best decision, as the textExtractor could reasonably extract numerical values, etc.

I realize this is likely not ready to pull in its existing state, but I would be happy to respond to any feedback to make this pull-ready. Thanks.

Example of a textExtractor:

Usage: `$( '.footable' ).footable({ textExtractor: myTextExtractor });`

```
    function myTextExtractor( node ) {
        var $td = $( node );
        var text = '';

        if (
            $td.is( '.classA' ) ||
            $td.is( '.classB' ) ||
            $td.is( '.classC' )
        ) {
            text = $td.find( 'span.rowScore' ).attr( 'data-original-title' );
        } else if (
            $td.is( '.classD' ),
            $td.is( '.classE' ),
        ) {
            text = $td.find( 'inpt[type="text"]' ).val();
        } else if (
            $td.is( '.classF' )
        ) {
            text = $td.find( 'option:selected' ).val();
        } else {
                           text = $td.text();
                    }

        if ( !text ) {
            text = '';
        }
        return text.trim();
    }
```
