### PR TITLE
Memory Plugin

### DIFF
--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -1,0 +1,21 @@
+(function ($, w, undefined) {
+
+    if (w.footable === undefined || w.foobox === null) {
+        throw new Error('Please check and make sure footable.js is included in the page and is loaded prior to this script.');
+    }
+
+    if ($.cookie === undefined ) {
+        throw new Error('Footable Memory requires jQuery $.cookie, https://github.com/carhartl/jquery-cookie');
+    }
+
+    function Memory() {
+        var p = this;
+        p.name = 'Footable Memory';
+        p.init = function(ft) {
+
+        };
+    }
+
+    w.footable.plugins.register(Memory, defaults);
+
+})(jQuery, window);

--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -8,11 +8,65 @@
         throw new Error('Footable Memory requires jQuery $.cookie, https://github.com/carhartl/jquery-cookie');
     }
 
+    var defaults = {
+        memory: {
+            enabled: false
+        }
+    };
+
+    var storage = {
+        get: function(index){
+
+        },
+        set: function(index, item){
+
+        }
+    };
+
+    var state = {
+        get: function(ft){
+
+        },
+        set: function(ft, data){
+
+        }
+    };
+
+    var is_enabled = function(ft){
+        return ft.options.memory.enabled
+    };
+
+    var update = function(ft, event) {
+        var index = ft.id,
+            data = state.get(ft);
+
+        storage.set(index, data);
+    };
+
+    var load = function(ft){
+        var index = ft.id,
+            data = storage.get(index);
+
+        state.set(ft, data);
+        ft.memory_plugin_loaded = true;
+    };
+
     function Memory() {
         var p = this;
         p.name = 'Footable Memory';
         p.init = function(ft) {
-
+            if (is_enabled(ft)) {
+                $(ft.table).bind({
+                    'footable_initialized': function(){
+                        load(ft);
+                    },
+                    'footable_page_filled footable_redrawn footable_filtered footable_sorted footable_row_expanded footable_row_collapsed': function(e) {
+                        if (ft.memory_plugin_loaded) {
+                            update(ft, e);
+                        }
+                    }
+                });
+            }
         };
     }
 

--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -1,7 +1,7 @@
 /**
  * Footable Memory 
  *
- * Version 1.0.3
+ * Version 1.0.5
  *
  * Requires jQuery Cookie (https://github.com/carhartl/jquery-cookie)
  *
@@ -34,10 +34,6 @@
 
     if (w.footable === undefined || w.foobox === null) {
         throw new Error('Please check and make sure footable.js is included in the page and is loaded prior to this script.');
-    }
-
-    if ($.cookie === undefined ) {
-        throw new Error('Footable Memory requires jQuery $.cookie, https://github.com/carhartl/jquery-cookie');
     }
 
     var defaults = {
@@ -349,6 +345,10 @@
         p.name = 'Footable Memory';
         p.init = function(ft) {
             if (is_enabled(ft)) {
+                if ($.cookie === undefined ) {
+                    throw new Error('Footable Memory requires jQuery $.cookie, https://github.com/carhartl/jquery-cookie');
+                }
+
                 $(ft.table).bind({
                     'footable_initialized': function(){
                         load(ft);

--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -1,3 +1,35 @@
+/**
+ * Footable Memory 
+ *
+ * Version 1.0.3
+ *
+ * Requires jQuery Cookie (https://github.com/carhartl/jquery-cookie)
+ *
+ * Stores table state in a cookie and reloads state when page is refreshed.
+ *
+ * Supports common Footable features:
+ * - Pagination
+ * - Sorting
+ * - Filtering
+ * - Expansion
+ *
+ * Written to be compatible with multiple Footables per page and with
+ * JavaScript libraries like AngularJS and Ember that use hash based URLs.
+ *
+ * Disabled by default, to enable add the following section to the footable
+ * options:
+ *
+ *   $('#table').footable({
+ *     memory: {
+ *       enabled: true
+ *     }
+ *   });
+ *
+ * Based on Footable Plugin Bookmarkable by Amy Farrell (https://github.com/akf)
+ *
+ * Created by Chris Laskey (https://github.com/chrislaskey)
+ */
+
 (function ($, w, undefined) {
 
     if (w.footable === undefined || w.foobox === null) {

--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -14,14 +14,115 @@
         }
     };
 
-    var storage = {
-        get: function(index){
+    var storage = (function($){
 
-        },
-        set: function(index, item){
+        'use strict';
 
-        }
-    };
+        /**
+         * Stores footable bookmarkable data in a cookie
+         *
+         * By default will store each page in its own cookie.
+         * Supports multiple FooTables per page.
+         * Supports JS frameworks that use hashmap URLs (AngularJS, Ember, etc).
+         *
+         * For example take an example application:
+         *
+         *     http://example.com/application-data (2 FooTables on this page)
+         *     http://example.com/application-data/#/details (1 FooTable on this page)
+         *     http://example.com/other-data (1 FooTable on this page)
+         *
+         * Would be stored like this:
+         *
+         *     cookie['/application-data'] = {
+         *         '/': {
+         *             1: {
+         *                 key1: value1,
+         *                 key2: value2
+         *             },
+         *             2: {
+         *                 key1: value1,
+         *                 key2: value2
+         *             }
+         *         },
+         *         '#/details': {
+         *             1: {
+         *                 key1: value1,
+         *                 key2: value2
+         *             }
+         *         }
+         *     };
+         *
+         *     cookie['/other-data'] = {
+         *         '/': {
+         *             1: {
+         *                 key1: value1,
+         *                 key2: value2
+         *             },
+         *         }
+         *     }
+         *
+         */
+
+        $.cookie.json = true;
+
+        var days_to_keep_data = 7;
+
+        var path_page = function(){
+            return location.pathname;
+        };
+
+        var path_subpage = function(){
+            return location.hash || '/';
+        };
+
+        var get_data = function(){
+            var page = path_page(),
+                data = $.cookie(page);
+
+            return data || {};
+        };
+
+        var get_table = function(index){
+            var subpage = path_subpage(),
+                data = get_data();
+
+            if( data[subpage] && data[subpage][index] ){
+                return data[subpage][index];
+            } else {
+                return {};
+            }
+        };
+
+        var set = function(index, item){
+            var page = path_page(),
+                subpage = path_subpage(),
+                data = get_data(),
+                options;
+
+            if( !data[subpage] ){
+                data[subpage] = {};
+            }
+
+            data[subpage][index] = item;
+
+            options = {
+                path: page,
+                expires: days_to_keep_data
+            }
+
+            $.cookie(page, data, options);
+        };
+
+        return {
+            get: function(index){
+                return get_table(index);
+            },
+            set: function(index, item){
+                set(index, item);
+            }
+        };
+
+    })($);
 
     var state = {
         get: function(ft){

--- a/js/footable.memory.js
+++ b/js/footable.memory.js
@@ -140,7 +140,7 @@
             options = {
                 path: page,
                 expires: days_to_keep_data
-            }
+            };
 
             $.cookie(page, data, options);
         };
@@ -326,7 +326,7 @@
     })($);
 
     var is_enabled = function(ft){
-        return ft.options.memory.enabled
+        return ft.options.memory.enabled;
     };
 
     var update = function(ft, event) {


### PR DESCRIPTION
Hey there!

I recently wrote a FooTable plugin and thought others might find it useful. 

The plugin is called Memory and saves the table state in a cookie and restores the state when the page is reloaded.

It supports the common FooTable features like:
- Pagination
- Sorting
- Filtering
- Row Expansion

And it is compatible with multiple FooTable instances on a page, and with JavaScript libraries that use hash-based URLs like AngularJS and Ember.

Since it uses cookies for data storage, it adds a dependency on jQuery Cookie (https://github.com/carhartl/jquery-cookie).

The idea came from the Bookmarkable plugin by @akf (Amy Farrell).
