### PR TITLE
Feature/npm semantic versioning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "footable",
-    "version": "2.0.1.5",
+    "version": "2.0.2",
     "description": "jQuery plugin to make HTML tables responsive",
     "keywords": [
         "table",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "footable",
   "title": "FooTable",
   "description": "jQuery plugin to make HTML tables responsive",
-  "version": "2.0.1.5",
+  "version": "2.0.2",
   "homepage": "http://themergency.com/footable/",
   "author": {
     "name": "FooPlugins",


### PR DESCRIPTION
As is the version causes dependency installation with `npm install` to fail:

```
npm ERR! install Couldn't read dependencies
npm ERR! Darwin 13.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.10.32
npm ERR! npm  v2.0.0

**npm ERR! Invalid version: "2.0.1.5"**
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <http://github.com/npm/npm/issues>
```

This is because npm requires [semantic versioning](http://semver.org/), which follows the pattern: MAJOR.MINOR.PATCH-pre-release-label.

Looking at the history 2.0.2 seems to be the appropriate patch number, but you probably know best.
