### PR TITLE
Support for html form input fields and dynamic column content

### DIFF
--- a/demos/data-attributes.htm
+++ b/demos/data-attributes.htm
@@ -118,6 +118,15 @@
                     <td><code>data-group</code></td>
                     <td>Used to group column headers together. This will also group the row details together.</td>
                 </tr>
+                <tr>
+                    <td><code>data-editable</code></td>
+                    <td>
+                    	Used to mark columns as editable. Set it as true to make a column editable/modifiable.
+                        By default if a cell contains any html input elements it will behave as editable/modifiable.
+                        Set to false if you do not need it.
+                    </td>
+                    <td><pre>&lt;th data-editable='true'&gt;</pre></td>
+                </tr>
                 <tr class="footable-disabled">
                     <td colspan="3"><h4>Sorting Data Attributes</h3></td>
                 </tr>

--- a/demos/editable-columns.htm
+++ b/demos/editable-columns.htm
@@ -1,0 +1,128 @@
+﻿<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>FooTable - jQuery plugin for responsive HTML tables</title>
+    <meta name="viewport" content="width = device-width, initial-scale = 1.0, minimum-scale = 1.0, maximum-scale = 1.0, user-scalable = no"/>
+	<link href="css/bootstrap.css" rel="stylesheet" type="text/css"/>
+	<link href="../css/footable.core.css?v=2-0-1" rel="stylesheet" type="text/css"/>
+    <link href="css/footable-demos.css" rel="stylesheet" type="text/css"/>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js" type="text/javascript"></script>
+    <script>
+        if (!window.jQuery) { document.write('<script src="js/jquery-1.9.1.min.js"><\/script>'); }
+    </script>
+    <script src="../js/footable.js?v=2-0-1" type="text/javascript"></script>
+	<script src="js/bootstrap-tab.js" type="text/javascript"></script>
+    <script src="js/demos.js" type="text/javascript"></script>
+</head>
+<body>
+	<div class="demo-container">
+        <ul class="breadcrumb">
+            <li><a href="http://fooplugins.com/plugins/footable-jquery/">FooTable</a> <span class="divider">&raquo;</span></li>
+            <li><a href="index.htm">Demos</a> <span class="divider">&raquo;</span></li>
+            <li class="active">Editable/Modifiable Columns</li>
+        </ul>
+        <div class="alert">
+            Support for columns with dynamic content. Play with the data to check if it retains data from phone/tablet to desktop.
+        </div>
+		<ul class="nav nav-tabs">
+			<li class="active"><a href="#demo">Demo</a></li>
+			<li><a href="#docs">Docs</a></li>
+		</ul>
+		<div class="tab-content">
+			<div class="tab-pane active" id="demo">
+				<div>
+					<a href="#" onclick="$('table').width('1100px');update();$('.footable').trigger('footable_resize');update();">[Desktop]</a>
+					<a href="#" onclick="$('table').width('800px');update();$('.footable').trigger('footable_resize');update();">[Tablet]</a>
+					<a href="#" onclick="$('table').width('400px');update();$('.footable').trigger('footable_resize');update();">[Phone]</a>
+				</div>
+				<table style="width: 800px;" class="table demo table-bordered">
+					<thead>
+						<tr>
+							<th>
+								Car Name
+							</th>
+							<th data-hide="phone,tablet">
+								<a href="#" width="100%" title="[editable=default/none]">Make</a>
+							</th>
+							<th data-editable="true" data-hide="phone,tablet">
+								<a href="#" width="100%" title="[editable=true]">Year Of Manufacture</a>
+							</th>
+							<th data-editable="false" data-hide="phone,tablet">
+								<a href="#" width="100%" title="[editable=false]">Odometer</a>
+							</th>
+							<th>
+								Summary
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Land Cruiser</td>
+							<td>
+								<select id="t1">
+									<option>Toyota</option>
+									<option>Nissan</option>
+									<option>Suzuki</option>
+								</select>
+							</td>
+							<td><input id="t2" type="text" value="2013" /></td>
+							<td><input id="t3" type="text" value="0" />KM</td>
+							<td id="Toyota"></td>
+						</tr>
+						<tr>
+							<td>Path Finder</td>
+							<td>
+								<select id="n1">
+									<option>Toyota</option>
+									<option>Nissan</option>
+									<option>Suzuki</option>
+								</select>
+							</td>
+							<td><input id="n2" type="text" value="2011" /></td>
+							<td><input id="n3" type="text" value="0" />KM</td>
+							<td id="Nissan"></td>
+						</tr>
+						<tr>
+							<td>Swift</td>
+							<td>
+								<select id="s1">
+									<option>Toyota</option>
+									<option>Nissan</option>
+									<option>Suzuki</option>
+								</select>
+							</td>
+							<td><input id="s2" type="text" value="2012" /></td>
+							<td><input id="s3" type="text" value="0" />KM</td>
+							<td id="Suzuki"></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<div class="tab-pane" id="docs">
+				<h4>Editable/Modifiable Columns</h4>
+				<p>Use data-editable attribute for retaining the dynamic cell value <code>data-editable="true"</code>:</p>
+                <pre>
+&lt;table&gt;
+	&lt;thead&gt;
+		&lt;th&gt;A1&lt;/th&gt;
+		&lt;th data-editable=&quot;false&quot;&gt;A2&lt;/th&gt;
+		&lt;th data-editable=&quot;true&quot;&gt;A3&lt;/th&gt;
+	&lt;/thead&gt;
+&lt;/table&gt;
+                </pre>
+            </div>
+		</div>
+	</div>
+    <script type="text/javascript">
+        $(function () {
+			$('table').footable();
+			update();
+        });
+        function update() {
+        	$("#Toyota").html($("<div></div>").append($("#t1").val() + ", Year-" + $("#t2").val() + ", Mileage-" + $("#t3").val()));
+        	$("#Nissan").html($("<div></div>").append($("#n1").val() + ", Year-" + $("#n2").val() + ", Mileage-" + $("#n3").val()));
+        	$("#Suzuki").html($("<div></div>").append($("#s1").val() + ", Year-" + $("#s2").val() + ", Mileage-" + $("#s3").val()));
+        }
+    </script>
+</body>
+</html>

--- a/demos/index.htm
+++ b/demos/index.htm
@@ -24,7 +24,8 @@
             <li><a>[TODO] Using Colspan</a> - FooTable support the use of colspan in your tables.</li>
             <li><a>[TODO] Controls</a> - do you use other 3rd party controls inside your tables?</li>
             <li><a>[TODO] Zebra Stripes</a> - how to get your zebra stripes to work.</li>
-	    <li><a href="arbitrary_toggle_markup.htm">Arbitrary Expand/Collapse Markup</a> - replace the toggler icons with your own (non-background) content</li>
+	        <li><a href="arbitrary_toggle_markup.htm">Arbitrary Expand/Collapse Markup</a> - replace the toggler icons with your own (non-background) content</li>
+	        <li><a href="editable-columns.htm">Editable / Modifiable Columns</a> - support for html input elements and dynamic columns.</li>
         </ul>
         <h3>Add-On Demos</h3>
         <ul>

--- a/js/footable.js
+++ b/js/footable.js
@@ -809,7 +809,7 @@
                 var bindValue = $('.' + cls.detailInnerValue + '[' + 'data-bind-value="' + bindName + '"]');
                 if(bindValue != null) {
                     if($(column).is(":visible")) {
-	        			if(!$(bindValue).is(':empty')) $(column).html($(bindValue).contents().detach());
+                        if(!$(bindValue).is(':empty')) $(column).html($(bindValue).contents().detach());
                     } else if(!$(column).is(':empty')) {
                         $(bindValue).html($(column).contents().detach());
                     }

--- a/js/footable.js
+++ b/js/footable.js
@@ -100,7 +100,7 @@
             triggers: {
                 initialize: 'footable_initialize',                      //trigger this event to force FooTable to reinitialize
                 resize: 'footable_resize',                              //trigger this event to force FooTable to resize
-                redraw: 'footable_redraw',                            	//trigger this event to force FooTable to redraw
+                redraw: 'footable_redraw',                              //trigger this event to force FooTable to redraw
                 toggleRow: 'footable_toggle_row',                       //trigger this event to force FooTable to toggle a row
                 expandFirstRow: 'footable_expand_first_row',            //trigger this event to force FooTable to expand the first row
                 expandAll: 'footable_expand_all',                       //trigger this event to force FooTable to expand all rows
@@ -739,7 +739,7 @@
                 if (index in column.names) name = column.names[index];
 
                 var bindName = $(this).attr("data-bind-name");
-                if (bindName != null && $(this).contents().length == 0) {
+                if (bindName != null && $(this).is(':empty')) {
                     var bindValue = $('.' + cls.detailInnerValue + '[' + 'data-bind-value="' + bindName + '"]');
                     $(this).html($(bindValue).contents().detach());
                 }

--- a/js/footable.js
+++ b/js/footable.js
@@ -808,8 +808,8 @@
             if(bindName != null) {
                 var bindValue = $('.' + cls.detailInnerValue + '[' + 'data-bind-value="' + bindName + '"]');
                 if(bindValue != null) {
-                    if($(column).is(":visible") && !$(bindValue).is(':empty')) {
-                        $(column).html($(bindValue).contents().detach());
+                    if($(column).is(":visible")) {
+	        			if(!$(bindValue).is(':empty')) $(column).html($(bindValue).contents().detach());
                     } else if(!$(column).is(':empty')) {
                         $(bindValue).html($(column).contents().detach());
                     }

--- a/js/footable.js
+++ b/js/footable.js
@@ -76,7 +76,9 @@
 
                     for (var j = 0; j < groups[group].data.length; j++) {
                         var separator = (groups[group].data[j].name) ? separatorChar : '';
-                        element.append('<div class="' + classes.detailInnerRow + '"><div class="' + classes.detailInnerName + '">' + groups[group].data[j].name + separator + '</div><div class="' + classes.detailInnerValue + '">' + groups[group].data[j].display + '</div></div>');
+                        element.append($('<div></div>').addClass(classes.detailInnerRow).append($('<div></div>').addClass(classes.detailInnerName)
+                                .append(groups[group].data[j].name + separator)).append($('<div></div>').addClass(classes.detailInnerValue)
+                                .attr('data-bind-value', groups[group].data[j].bindName).append(groups[group].data[j].display)));
                     }
                 }
             },
@@ -98,7 +100,7 @@
             triggers: {
                 initialize: 'footable_initialize',                      //trigger this event to force FooTable to reinitialize
                 resize: 'footable_resize',                              //trigger this event to force FooTable to resize
-                redraw: 'footable_redraw',								//trigger this event to force FooTable to redraw
+                redraw: 'footable_redraw',                            	//trigger this event to force FooTable to redraw
                 toggleRow: 'footable_toggle_row',                       //trigger this event to force FooTable to toggle a row
                 expandFirstRow: 'footable_expand_first_row',            //trigger this event to force FooTable to expand the first row
                 expandAll: 'footable_expand_all',                       //trigger this event to force FooTable to expand all rows
@@ -212,7 +214,7 @@
         return this.each(function () {
             instanceCount++;
             var footable = new Footable(this, o, instanceCount);
-			$(this).data('footable', footable);
+            $(this).data('footable', footable);
         });
     };
 
@@ -385,7 +387,7 @@
                 if (col.toggle) {
                     hasToggleColumn = true;
                     var selector = '> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > td:nth-child(' + (parseInt(col.index, 10) + 1) + '),' +
-											'> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > th:nth-child(' + (parseInt(col.index, 10) + 1) + ')';
+                                            '> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > th:nth-child(' + (parseInt(col.index, 10) + 1) + ')';
                     $table.find(selector).not('.' + cls.detailCell).prepend($(opt.toggleHTMLElement).addClass(cls.toggle));
                     return;
                 }
@@ -394,7 +396,7 @@
             if (!hasToggleColumn) {
                 $table
                     .find('> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > td:first-child')
-										.add('> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > th:first-child')
+                                        .add('> tbody > tr:not(.' + cls.detail + ',.' + cls.disabled + ') > th:first-child')
                     .not('.' + cls.detailCell)
                     .prepend($(opt.toggleHTMLElement).addClass(cls.toggle));
             }
@@ -457,7 +459,8 @@
                 'matches': [],
                 'names': { },
                 'group': $th.data('group') || null,
-                'groupName': null
+                'groupName': null,
+                'isEditable': $th.data('editable')
             };
 
             if (data.group !== null) {
@@ -637,6 +640,10 @@
                     ft.createOrUpdateDetailRow(this);
                 });
 
+            $table.find("[data-bind-name]").each(function () {
+                ft.toggleInput(this);
+            });
+
             $table.find('> tbody > tr.' + cls.detailShow + ':visible').each(function () {
                 var $next = $(this).next();
                 if ($next.hasClass(cls.detail)) {
@@ -675,7 +682,7 @@
             } else {
                 ft.createOrUpdateDetailRow($row[0]);
                 $row.addClass(cls.detailShow)
-					.next().show();
+                    .next().show();
 
                 ft.raise(evt.rowExpanded, { 'row': $row[0] });
             }
@@ -730,7 +737,22 @@
                 if (column.ignore === true) return true;
 
                 if (index in column.names) name = column.names[index];
-                values.push({ 'name': name, 'value': ft.parse(this, column), 'display': $.trim($(this).html()), 'group': column.group, 'groupName': column.groupName });
+
+                var bindName = $(this).attr("data-bind-name");
+                if (bindName != null && $(this).contents().length == 0) {
+                    var bindValue = $('.' + cls.detailInnerValue + '[' + 'data-bind-value="' + bindName + '"]');
+                    $(this).html($(bindValue).contents().detach());
+                }
+                var display;
+                if (column.isEditable !== false && (column.isEditable || $(this).find(":input").length > 0)) {
+                    if(bindName == null) {
+                        bindName = "bind-" + $.now() + "-" + index;
+                        $(this).attr("data-bind-name", bindName);
+                    }
+                    display = $(this).contents().detach();
+                }
+                if (!display) display = $(this).contents().clone(true, true);
+                values.push({ 'name': name, 'value': ft.parse(this, column), 'display': display, 'group': column.group, 'groupName': column.groupName, 'bindName': bindName });
                 return true;
             });
             if (values.length === 0) return false; //return if we don't have any data to show
@@ -778,6 +800,21 @@
             $table.find('> tbody > tr.' + cls.detail).remove();
 
             ft.raise(evt.reset);
+        };
+
+        //Switch between row-detail and detail-show.
+        ft.toggleInput = function (column) {
+            var bindName = $(column).attr("data-bind-name");
+            if(bindName != null) {
+                var bindValue = $('.' + cls.detailInnerValue + '[' + 'data-bind-value="' + bindName + '"]');
+                if(bindValue != null) {
+                    if($(column).is(":visible") && !$(bindValue).is(':empty')) {
+                        $(column).html($(bindValue).contents().detach());
+                    } else if(!$(column).is(':empty')) {
+                        $(bindValue).html($(column).contents().detach());
+                    }
+                }
+            }
         };
 
         ft.init();


### PR DESCRIPTION
To overcome issues 194 & 156. Switches/moves content between row-detail and detail-show. It includes the demo/documentation. Added a data attribute data-editable, it achieves by using a mapping variable and moving data between the row-detail and detail-show. By default it creates the map for any cell which has form input elements.
