### PR TITLE
Include boolean parameter 'redraw' so we can prevent redraw for bulk rows additions

### DIFF
--- a/src/js/components/core/editing/extends/FooTable.Rows.js
+++ b/src/js/components/core/editing/extends/FooTable.Rows.js
@@ -4,13 +4,13 @@
 	 * Adds a row to the underlying {@link FooTable.Rows#all} array.
 	 * @param {(object|FooTable.Row)} dataOrRow - A hash containing the row values or an actual {@link FooTable.Row} object.
 	 */
-	F.Rows.prototype.add = function(dataOrRow){
+	F.Rows.prototype.add = function(dataOrRow, redraw){
 		var row = dataOrRow;
 		if (F.is.hash(dataOrRow)){
 			row = new FooTable.Row(this.ft, this.ft.columns.array, dataOrRow);
 		}
 		if (row instanceof FooTable.Row){
-			row.add();
+			row.add(redraw);
 		}
 	};
 


### PR DESCRIPTION
…e for bulk rows addition.

Since F.Rows.prototype.add utilises row.add() which has a 'redraw' parameter. This allows us to do something like this when adding rows in bulk:

```
$.each( data, function() {
    values = {
        ...
    }
    // Add rows without redrawing
    ft.rows.add(values, false);
});

// Redraw tables after bulk add
ft.draw();
```
