### PR TITLE
Icon for view button

### DIFF
--- a/src/css/FooTable.Glyphicons.css
+++ b/src/css/FooTable.Glyphicons.css
@@ -55,3 +55,6 @@
 .fooicon-cog:before {
 	content: "\e019";
 }
+.fooicon-stats:before {
+	content: "\e185";
+}


### PR DESCRIPTION
Implemented stats icon for view button - as proposed in src/js/components/core/editing/FooTable.Editing.js
