### PR TITLE
Increase .footable-editing width to accomdate one more 'view' button

### DIFF
--- a/src/css/components/FooTable.Editing.css
+++ b/src/css/components/FooTable.Editing.css
@@ -1,6 +1,6 @@
 td.footable-editing {
-	width: 70px;
-	max-width: 70px;
+	width: 90px;
+	max-width: 90px;
 }
 table.footable-editing-right td.footable-editing,
 table.footable-editing-right tr.footable-editing {


### PR DESCRIPTION
Increase width to accomodate view button - as proposed in src/js/components/core/editing/FooTable.Editing.js
