### PR TITLE
Add a title in filtering dropdown menu

### DIFF
--- a/src/js/components/filtering/FooTable.Filtering.js
+++ b/src/js/components/filtering/FooTable.Filtering.js
@@ -249,17 +249,19 @@
 				.on('click', { self: self }, self._onSearchButtonClicked)
 				.append($('<span/>', {'class': 'fooicon fooicon-search'}));
 
-			self.$dropdown = $('<ul/>', {'class': 'dropdown-menu dropdown-menu-right'}).append(
-				F.arr.map(self.ft.columns.array, function (col) {
-					return col.filterable ? $('<li/>').append(
-						$('<a/>', {'class': 'checkbox'}).append(
-							$('<label/>', {text: col.title}).prepend(
-								$('<input/>', {type: 'checkbox', checked: true}).data('__FooTableColumn__', col)
+			self.$dropdown = $('<ul/>', {'class': 'dropdown-menu dropdown-menu-right'})
+				.append($('<li/>', {'class': 'dropdown-header','text': 'Search in:'}))
+				.append(
+					F.arr.map(self.ft.columns.array, function (col) {
+						return col.filterable ? $('<li/>').append(
+							$('<a/>', {'class': 'checkbox'}).append(
+								$('<label/>', {text: col.title}).prepend(
+									$('<input/>', {type: 'checkbox', checked: true}).data('__FooTableColumn__', col)
+								)
 							)
-						)
-					) : null;
-				})
-			);
+						) : null;
+					})
+				);
 
 			if (self.delay > 0){
 				self.$input.on('keypress keyup paste', { self: self }, self._onSearchInputChanged);


### PR DESCRIPTION
Real users thought that checkboxes were used for toggling hide/show of table columns. So when they toggled checkboxes and nothing happened, they thought the table was brokened. Adding a title to indicate that checkboxes are filters for the search.
