### PR TITLE
Added a specific class for footable's default search filter

### DIFF
--- a/src/js/components/filtering/FooTable.Filtering.js
+++ b/src/js/components/filtering/FooTable.Filtering.js
@@ -248,7 +248,7 @@
 		$create: function () {
 			var self = this;
 			// generate the cell that actually contains all the UI.
-			var $form_grp = $('<div/>', {'class': 'form-group'})
+			var $form_grp = $('<div/>', {'class': 'form-group search-filter'})
 					.append($('<label/>', {'class': 'sr-only', text: 'Search'})),
 				$input_grp = $('<div/>', {'class': 'input-group'}).appendTo($form_grp),
 				$input_grp_btn = $('<div/>', {'class': 'input-group-btn'}),

--- a/src/js/components/filtering/FooTable.Filtering.js
+++ b/src/js/components/filtering/FooTable.Filtering.js
@@ -248,7 +248,7 @@
 		$create: function () {
 			var self = this;
 			// generate the cell that actually contains all the UI.
-			var $form_grp = $('<div/>', {'class': 'form-group search-filter'})
+			var $form_grp = $('<div/>', {'class': 'form-group footable-filtering-search'})
 					.append($('<label/>', {'class': 'sr-only', text: 'Search'})),
 				$input_grp = $('<div/>', {'class': 'input-group'}).appendTo($form_grp),
 				$input_grp_btn = $('<div/>', {'class': 'input-group-btn'}),


### PR DESCRIPTION
Added search-filter class to the default search filter element - so we can target it with css or js - e.g. to hide it in a scenario where we have other custom filtering elements inside `.footable-filtering` so we can't hide the whole `.footable-filtering` table row as mentioned in the examples.
