### PR TITLE
Prevent unnecessary browsers reflows and hide flash of unstyled content

### DIFF
--- a/src/css/FooTable.css
+++ b/src/css/FooTable.css
@@ -8,6 +8,9 @@ table.footable-details {
 table.footable-details {
 	margin-bottom: 0;
 }
+table.footable-hide-fouc {
+	display: none;
+}
 table > tbody > tr > td > span.footable-toggle {
 	margin-right: 8px;
 	opacity: 0.3;

--- a/src/js/classes/FooTable.Table.js
+++ b/src/js/classes/FooTable.Table.js
@@ -47,6 +47,12 @@
 			 */
 			this.$el = (F.is.jq(element) ? element : $(element)).first(); // ensure one table, one instance
 			/**
+			 * A loader jQuery instance
+			 * @instance
+			 * @type {jQuery}
+			 */
+			this.$loader = $('<div/>', { 'class': 'footable-loader' }).append($('<span/>', {'class': 'fooicon fooicon-loader'}));
+			/**
 			 * The options for the plugin. This is a merge of user defined options and the default options.
 			 * @instance
 			 * @type {object}
@@ -156,12 +162,9 @@
 				for (var i = 0, len = classes.length; i < len; i++){
 					if (!F.str.startsWith(classes[i], 'footable')) self.classes.push(classes[i]);
 				}
-				var $loader = $('<div/>', { 'class': 'footable-loader' }).append($('<span/>', {'class': 'fooicon fooicon-loader'}));
-				self.$el.hide().after($loader);
-				return self.execute(false, false, 'preinit', self.data).always(function(){
-					self.$el.show();
-					$loader.remove();
-				});
+
+				self.$el.hide().after(self.$loader);
+				return self.execute(false, false, 'preinit', self.data);
 			});
 		},
 		/**
@@ -292,6 +295,12 @@
 		 */
 		draw: function () {
 			var self = this;
+			// Hide the table to prevent flashes of partially styled or unstyled content as the table is initializing and drawing itself.
+			self.$el.css({
+				"display": self.$el.css("display") === "none" ? "none" : "block",
+				"height": self.$el.outerHeight(),
+				"visibility": "hidden"
+			});
 			// when drawing the order that the components are executed is important so chain the methods but use promises to retain async safety.
 			return self.execute(false, true, 'predraw').then(function(){
 				/**
@@ -325,6 +334,14 @@
 				if (F.is.error(err)){
 					console.error('FooTable: unhandled error thrown during a draw operation.', err);
 				}
+			}).always(function(){
+				// Set the table back to visible after the table has drawn itself.
+				self.$el.css({
+					"display": "table",
+					"height": "auto",
+					"visibility": "visible"
+				}).show();
+				self.$loader.remove();
 			});
 		},
 		/**

--- a/src/js/classes/FooTable.Table.js
+++ b/src/js/classes/FooTable.Table.js
@@ -297,13 +297,8 @@
 		draw: function () {
 			var self = this;
 
-			// Copy `self.$el` with no event handlers
-			var $elCopy = $(self.$el[0].outerHTML);
-
-			// Insert the copy at the same location as `self.$el`
-			self.$el.prev().length === 0
-				? self.$el.parent().prepend($elCopy)
-				: self.$el.prev().after($elCopy);
+			// Clone the current table and insert it into the original's place
+			var $elCopy = self.$el.clone().insertBefore(self.$el);
 
 			// Detach `self.$el` from the DOM, retaining its event handlers
 			self.$el.detach();

--- a/src/js/classes/FooTable.Table.js
+++ b/src/js/classes/FooTable.Table.js
@@ -118,7 +118,7 @@
 			this._preinit().then(function(){
 				return self._init();
 			}).always(function(arg){
-				self._showTable();
+				self.$el.show();
 				if (F.is.error(arg)){
 					console.error('FooTable: unhandled error thrown during initialization.', arg);
 				} else {
@@ -296,7 +296,18 @@
 		 */
 		draw: function () {
 			var self = this;
-			self._hideTable();
+
+			// Copy `self.$el` with no event handlers
+			var $elCopy = $(self.$el[0].outerHTML);
+
+			// Insert the copy at the same location as `self.$el`
+			self.$el.prev().length === 0
+				? self.$el.parent().prepend($elCopy)
+				: self.$el.prev().after($elCopy);
+
+			// Detach `self.$el` from the DOM, retaining its event handlers
+			self.$el.detach();
+
 			// when drawing the order that the components are executed is important so chain the methods but use promises to retain async safety.
 			return self.execute(false, true, 'predraw').then(function(){
 				/**
@@ -331,7 +342,9 @@
 					console.error('FooTable: unhandled error thrown during a draw operation.', err);
 				}
 			}).always(function(){
-				self._showTable();
+				// Replace the copy that we added above with the modified `self.$el`
+				$elCopy.replaceWith(self.$el);
+				self.$loader.remove();
 			});
 		},
 		/**
@@ -413,33 +426,6 @@
 					self.breakpoints.check();
 				});
 			}, 300);
-		},
-		/**
-		 * Hide the table to prevent flashes of partially styled or unstyled content as the table is initializing and drawing itself.
-		 * @instance
-		 * @private
-		 */
-		_hideTable: function() {
-			var self = this;
-			self.$el.css({
-				"display": self.$el.css("display") === "none" ? "none" : "block",
-				"height": self.$el.outerHeight(),
-				"visibility": "hidden"
-			});
-		},
-		/**
-		 * Shows the table element and removes the loader
-		 * @instance
-		 * @private
-		 */
-		_showTable: function() {
-			var self = this;
-			self.$el.css({
-				"display": "table",
-				"height": "auto",
-				"visibility": "visible"
-			}).show();
-			self.$loader.remove();
 		}
 	});
 

--- a/src/js/classes/FooTable.Table.js
+++ b/src/js/classes/FooTable.Table.js
@@ -118,6 +118,7 @@
 			this._preinit().then(function(){
 				return self._init();
 			}).always(function(arg){
+				self._showTable();
 				if (F.is.error(arg)){
 					console.error('FooTable: unhandled error thrown during initialization.', arg);
 				} else {
@@ -295,12 +296,7 @@
 		 */
 		draw: function () {
 			var self = this;
-			// Hide the table to prevent flashes of partially styled or unstyled content as the table is initializing and drawing itself.
-			self.$el.css({
-				"display": self.$el.css("display") === "none" ? "none" : "block",
-				"height": self.$el.outerHeight(),
-				"visibility": "hidden"
-			});
+			self._hideTable();
 			// when drawing the order that the components are executed is important so chain the methods but use promises to retain async safety.
 			return self.execute(false, true, 'predraw').then(function(){
 				/**
@@ -335,13 +331,7 @@
 					console.error('FooTable: unhandled error thrown during a draw operation.', err);
 				}
 			}).always(function(){
-				// Set the table back to visible after the table has drawn itself.
-				self.$el.css({
-					"display": "table",
-					"height": "auto",
-					"visibility": "visible"
-				}).show();
-				self.$loader.remove();
+				self._showTable();
 			});
 		},
 		/**
@@ -423,6 +413,33 @@
 					self.breakpoints.check();
 				});
 			}, 300);
+		},
+		/**
+		 * Hide the table to prevent flashes of partially styled or unstyled content as the table is initializing and drawing itself.
+		 * @instance
+		 * @private
+		 */
+		_hideTable: function() {
+			var self = this;
+			self.$el.css({
+				"display": self.$el.css("display") === "none" ? "none" : "block",
+				"height": self.$el.outerHeight(),
+				"visibility": "hidden"
+			});
+		},
+		/**
+		 * Shows the table element and removes the loader
+		 * @instance
+		 * @private
+		 */
+		_showTable: function() {
+			var self = this;
+			self.$el.css({
+				"display": "table",
+				"height": "auto",
+				"visibility": "visible"
+			}).show();
+			self.$loader.remove();
 		}
 	});
 

--- a/src/js/components/paging/FooTable.Paging.js
+++ b/src/js/components/paging/FooTable.Paging.js
@@ -490,9 +490,9 @@
 			}
 
 			if (this.limit > 0 && this.total < this.limit){
-				this.$pagination.children('li[data-page="prev-limit"],li[data-page="next-limit"]').hide();
+				this.$pagination.children('li[data-page="prev-limit"],li[data-page="next-limit"]').css('display', 'none');
 			} else {
-				this.$pagination.children('li[data-page="prev-limit"],li[data-page="next-limit"]').show();
+				this.$pagination.children('li[data-page="prev-limit"],li[data-page="next-limit"]').css('display', '');
 			}
 
 			if (active){


### PR DESCRIPTION
This PR addresses #472, where using jQuery 3+ with FooTable would cause a tremendous number of repaints and reflows in the browser. The concept behind this change is to remove the table from the DOM rendering flow while FooTable performs its draw operations and then placing it back once the table has been redrawn. During operations where height is generally not affected such as sorts, FooTable will also set the height directly on the table element before changing visibility to prevent reflows. 

Additionally, I have added a convenience class that users may add to their table html element which hides the table until the FooTable has been initialized. The goal again here is to hide FOUC until FooTable has initialized.