### PR TITLE
Display empty string instead of "Invalid date"

### DIFF
--- a/src/js/classes/columns/FooTable.DateColumn.js
+++ b/src/js/classes/columns/FooTable.DateColumn.js
@@ -63,7 +63,7 @@
 		 * @this FooTable.DateColumn
 		 */
 		formatter: function(value){
-			return F.is.object(value) && F.is.boolean(value._isAMomentObject) ? value.format(this.formatString) : '';
+			return F.is.object(value) && F.is.boolean(value._isAMomentObject) && value.isValid() ? value.format(this.formatString) : '';
 		},
 		/**
 		 * This is supplied either the cell value or jQuery object to parse. A string value must be returned from this method and will be used during filtering operations.


### PR DESCRIPTION
Moment.format() will return "Invalid date" if the value is not a parsable date string. Test that the data is valid before formatting, if not return an empty string.