### PR TITLE
Copy all cell attributes to detail when collapsing

### DIFF
--- a/src/js/classes/FooTable.Cell.js
+++ b/src/js/classes/FooTable.Cell.js
@@ -122,7 +122,7 @@
 			if (!this.created) return;
 			this.$detail.children('th').html(this.column.title);
 			this.$el.clone()
-				.removeAttr('id')
+				.attr('id', this.$el.attr('id') ? this.$el.attr('id') + '-detail' : undefined)
 				.css('display', 'table-cell')
 				.html('')
 				.append(this.$el.contents().detach())

--- a/src/js/classes/FooTable.Cell.js
+++ b/src/js/classes/FooTable.Cell.js
@@ -121,11 +121,12 @@
 		collapse: function(){
 			if (!this.created) return;
 			this.$detail.children('th').html(this.column.title);
-			this.$detail.children('td').first()
-				.attr('class', this.$el.attr('class'))
-				.attr('style', this.$el.attr('style'))
+			this.$el.clone()
+				.removeAttr('id')
 				.css('display', 'table-cell')
-				.append(this.$el.contents().detach());
+				.html('')
+				.append(this.$el.contents().detach())
+				.replaceAll(this.$detail.children('td').first());
 
 			if (!F.is.jq(this.$detail.parent()))
 				this.$detail.appendTo(this.row.$details.find('.footable-details > tbody'));


### PR DESCRIPTION
As the code currently exists, only the `class` and `style` attributes are copied from a cell to the corresponding cell in the expanded detail view. This has the downside of excluding data attributes that might be used in click handlers or other bindings.

This updates the logic to clone the cell, change its id (to prevent duplicates), and then replace the detail cell with the cloned element.