### PR TITLE
Add license key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "FooTable is a jQuery plugin that aims to make HTML tables on smaller devices look awesome.",
   "version": "3.1.4",
   "homepage": "http://fooplugins.com",
+  "license": "GPL-3.0",
   "author": {
     "name": "FooPlugins",
     "url": "http://fooplugins.com"


### PR DESCRIPTION
The [WebJars](http://www.webjars.org/) build service requires the license key to be present.