### PR TITLE
Only add loader if it isn't already a sibling of the element

### DIFF
--- a/src/js/classes/FooTable.Table.js
+++ b/src/js/classes/FooTable.Table.js
@@ -164,7 +164,11 @@
 					if (!F.str.startsWith(classes[i], 'footable')) self.classes.push(classes[i]);
 				}
 
-				self.$el.hide().after(self.$loader);
+				self.$el.hide();
+				if (!$.contains(document.documentElement, self.$loader.get(0))) {
+					self.$el.after(self.$loader);
+				}
+
 				return self.execute(false, false, 'preinit', self.data);
 			});
 		},


### PR DESCRIPTION
This updates the code to only add the loader if it's not already a sibling of the table element. This is useful for when a user wants to manually show the loader before reloading the table.