### PR TITLE
Fix unhandled error thrown during a draw operation

### DIFF
--- a/src/js/components/breakpoints/FooTable.Breakpoints.js
+++ b/src/js/components/breakpoints/FooTable.Breakpoints.js
@@ -118,7 +118,9 @@
 		 * @protected
 		 */
 		draw: function(){
-			this.ft.$el.removeClass(this._classNames).addClass('breakpoint-' + this.current.name);
+			if (this.current){
+				this.ft.$el.removeClass(this._classNames).addClass('breakpoint-' + this.current.name);
+			}
 		},
 
 		/* PUBLIC */
@@ -144,6 +146,7 @@
 			}
 			hidden.push(current.name);
 			self.hidden = hidden.join(' ');
+			self.current = current;
 			return current;
 		},
 		/**

--- a/src/js/components/editing/FooTable.Editing.js
+++ b/src/js/components/editing/FooTable.Editing.js
@@ -355,7 +355,9 @@
 		 * Performs the drawing of the component.
 		 */
 		draw: function(){
-			this.$cell.attr('colspan', this.ft.columns.visibleColspan);
+			if (this.enabled){
+				this.$cell.attr('colspan', this.ft.columns.visibleColspan);
+			}
 		},
 		/**
 		 * Handles the edit button click event.


### PR DESCRIPTION
Dear friends,

I propose patch that fixes "unhandled error thrown during a draw operation" in breakpoints and editing components. Please check and pull my changes if it's useful.

About fixes:
1. In breakpoints component I added missing current property assignment and check in draw method.
2. In editing component it's very important to check that component already initialized (check enabled property) before using $cell property because it's may be undefined.

Info:
This bug is very hard to catch (frequency of appearing is very small). I had used ``ft.rows.load`` method to add rows to table after Footable initialization. Sometimes I caught strange behavior -- table won't load rows and shows "No data" (or something similar). In console I got errors.

```
FooTable: unhandled error thrown during a draw operation. TypeError: Cannot read property 'attr' of undefined
    at Class.draw (footable.js:6403)
    at Object.<anonymous> (footable.js:2295)
    at Function.Deferred (jquery.min.js:2)
    at obj._execute (footable.js:2293)
    at Object.<anonymous> (footable.js:2305)
    at Object.<anonymous> (jquery.min.js:2)
    at i (jquery.min.js:2)
    at Object.add [as done] (jquery.min.js:2)
    at Array.<anonymous> (jquery.min.js:2)
    at Function.each (jquery.min.js:2)
```

```
FooTable: unhandled error thrown during a draw operation. TypeError: this.current is null
Stack trace:
F.Breakpoints<.draw@http://localhost/app/biobank/js/footable.js:2803:4
F.Table<._execute/<@http://localhost/app/biobank/js/footable.js:2295:19
.Deferred@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28971
F.Table<._execute@http://localhost/app/biobank/js/footable.js:2293:11
F.Table<.execute@http://localhost/app/biobank/js/footable.js:2269:11
F.Table<.draw/</<@http://localhost/app/biobank/js/footable.js:2221:13
.Deferred/d.then/</</<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28467
n.Callbacks/i@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27146
n.Callbacks/j.add@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27450
.Deferred/d.then/</<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28439
.each@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:2859
.Deferred/d.then/<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28385
.Deferred@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28971
.Deferred/d.then@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28362
F.Table<.draw/<@http://localhost/app/biobank/js/footable.js:2220:12
.Deferred/d.then/</</<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28467
n.Callbacks/i@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27146
n.Callbacks/j.add@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27450
.Deferred/d.then/</<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28439
.each@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:2859
.Deferred/d.then/<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28385
.Deferred@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28971
.Deferred/d.then@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:28362
F.Table<.draw@http://localhost/app/biobank/js/footable.js:2213:11
@http://localhost/app/biobank/js/footable.js:7189:10
__extend__/proto[name]</<@http://localhost/app/biobank/js/footable.js:775:13
F.Rows<.load@http://localhost/app/biobank/js/footable.js:3561:4
.success@http://localhost/app/biobank/js/tablehandlers.js:155:17
n.Callbacks/i@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27146
n.Callbacks/j.fireWith@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:2:27914
z@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:4:12057
.send/c/<@http://localhost/app/biobank/vendors/jquery/dist/jquery.min.js:4:15619
  footable.js:2243:6
```

May be connected with similar issue:
https://github.com/fooplugins/FooTable/issues/733

Thanks.
Alex.