### PR TITLE
Fix null or empty value passed to Date type cell displaying as the momentJs default (01-01-1970) in FooTable.DateColumn.js

### DIFF
--- a/src/js/classes/columns/FooTable.DateColumn.js
+++ b/src/js/classes/columns/FooTable.DateColumn.js
@@ -38,6 +38,7 @@
 				valueOrElement = F.is.defined(data) ? data : $(valueOrElement).text();
 				if (F.is.string(valueOrElement)) valueOrElement = isNaN(valueOrElement) ? valueOrElement : +valueOrElement;
 			}
+			if (valueOrElement === 0) return null;
 			if (F.is.date(valueOrElement)) return moment(valueOrElement);
 			if (F.is.object(valueOrElement) && F.is.boolean(valueOrElement._isAMomentObject)) return valueOrElement;
 			if (F.is.string(valueOrElement)){


### PR DESCRIPTION
Fix for passing a null or empty value to a cell marked as date type - currently displays as the momentJs default date of 01-01-1970. Instead, this returns early and displays blank/empty cell.