### PR TITLE
Apply thousandSeparator to integer values

### DIFF
--- a/src/js/classes/columns/FooTable.NumberColumn.js
+++ b/src/js/classes/columns/FooTable.NumberColumn.js
@@ -52,9 +52,7 @@
 		formatter: function(value, options, rowData){
 			if (value == null) return '';
 			var s = (value + '').split('.');
-			if (s.length == 2 && s[0].length > 3) {
-				s[0] = s[0].replace(/\B(?=(?:\d{3})+(?!\d))/g, this.thousandSeparator);
-			}
+			s[0] = s[0].replace(/\B(?=(?:\d{3})+(?!\d))/g, this.thousandSeparator);
 			return s.join(this.decimalSeparator);
 		}
 	});


### PR DESCRIPTION
When the `value` has no decimal part, `s.length` is 1 and `thousandSeparator` is not applied.
The `s.length == 2` check is excessive here, as well as the `s[0].length > 3`.
The function behaves fine without it.

Fixes fooplugins/FooTable#894